### PR TITLE
Fixes a bug causing the maximum stamina value to be lost when blocking instead of the current value.

### DIFF
--- a/src/OnMeleeHitHook.cpp
+++ b/src/OnMeleeHitHook.cpp
@@ -70,7 +70,7 @@ void OnMeleeHit::ProcessHit(RE::Actor* victim, RE::HitData& hitData) {
                 }
 
                 const float extraStaminaCost = staminaCostTimeBlockingMult * staminaCostPerksMult * 15.f;
-                victim->AsActorValueOwner()->ModActorValue(RE::ActorValue::kStamina, -extraStaminaCost);
+                victim->AsActorValueOwner()->RestoreActorValue(RE::ACTOR_VALUE_MODIFIER::kDamage, RE::ActorValue::kStamina, -extraStaminaCost);
             }
         }
     }


### PR DESCRIPTION
Fixing: Stamina bar shrinks and does not refill when stamina goes to 0 from a blocked hit.